### PR TITLE
Support exclude_weekends for PeriodicEvent

### DIFF
--- a/qf_lib/backtesting/events/time_event/periodic_event/periodic_event.py
+++ b/qf_lib/backtesting/events/time_event/periodic_event/periodic_event.py
@@ -140,6 +140,7 @@ class PeriodicEvent(TimeEvent, metaclass=ABCMeta):
                     _next_trigger_time = _start_time_rule.next_trigger_time(_next_trigger_time)
 
             if not self._run_on_weekends and _next_trigger_time.weekday() in (5, 6):
+                # recursive call to get the next valid trigger time
                 _next_trigger_time = self.next_trigger_time(_next_trigger_time)
 
             return _next_trigger_time

--- a/qf_lib/backtesting/events/time_event/periodic_event/periodic_event.py
+++ b/qf_lib/backtesting/events/time_event/periodic_event/periodic_event.py
@@ -271,5 +271,9 @@ class PeriodicEvent(TimeEvent, metaclass=ABCMeta):
 
     @classmethod
     def exclude_weekends(cls):
-        """ If called, the periodic event will not be notified over the weekends. """
+        """
+        If called, the periodic event will not be notified over the weekends.
+        Initiation of PeriodicEvent must be after setting the exclude_weekends because of the
+        PeriodicEvnet _events_list attribute
+        """
         cls._run_over_weekends = False

--- a/qf_lib/tests/unit_tests/backtesting/events/time_event/test_rules.py
+++ b/qf_lib/tests/unit_tests/backtesting/events/time_event/test_rules.py
@@ -147,6 +147,36 @@ class TestRules(TestCase):
         now = periodic_15_minutes_event.next_trigger_time(now)
         self.assertEqual(str_to_date("2018-01-02 9:45:00.000000", DateFormat.FULL_ISO), now)
 
+    def test_exclude_weekends__periodic_event(self):
+        class Periodic15MinutesEvent(PeriodicEvent):
+            frequency = Frequency.MIN_15
+            start_time = {"hour": 9, "minute": 45, "second": 0}
+            end_time = {"hour": 10, "minute": 0, "second": 0}
+
+            def notify(self, listener):
+                pass
+
+        Periodic15MinutesEvent.exclude_weekends()
+        periodic_event = Periodic15MinutesEvent()
+
+        # 11th of June 2022 is a Saturday
+        self.timer.set_current_time(str_to_date("2022-06-11 00:00:00.000000", DateFormat.FULL_ISO))
+        now = self.timer.now()
+        next_trigger_time = periodic_event.next_trigger_time(now)
+        self.assertEqual(str_to_date("2022-06-13 09:45:00.000000", DateFormat.FULL_ISO), next_trigger_time)
+
+        # 12th of June 2022 is a Sunday
+        self.timer.set_current_time(str_to_date("2022-06-12 00:00:00.000000", DateFormat.FULL_ISO))
+        now = self.timer.now()
+        next_trigger_time = periodic_event.next_trigger_time(now)
+        self.assertEqual(str_to_date("2022-06-13 09:45:00.000000", DateFormat.FULL_ISO), next_trigger_time)
+
+        # 13th of June 2022 is a Monday
+        self.timer.set_current_time(str_to_date("2022-06-13 00:00:00.000000", DateFormat.FULL_ISO))
+        now = self.timer.now()
+        next_trigger_time = periodic_event.next_trigger_time(now)
+        self.assertEqual(str_to_date("2022-06-13 09:45:00.000000", DateFormat.FULL_ISO), next_trigger_time)
+
     def test_single_time_events(self):
         self.timer.set_current_time(str_to_date("2018-01-01 13:00:00.000000", DateFormat.FULL_ISO))
         now = self.timer.now()

--- a/qf_lib/tests/unit_tests/backtesting/events/time_event/test_rules.py
+++ b/qf_lib/tests/unit_tests/backtesting/events/time_event/test_rules.py
@@ -156,6 +156,7 @@ class TestRules(TestCase):
             def notify(self, listener):
                 pass
 
+        # initiation must be after setting the exclude_weekends because of the PeriodicEvnet _events_list attribute
         Periodic15MinutesEvent.exclude_weekends()
         periodic_event = Periodic15MinutesEvent()
 


### PR DESCRIPTION
Hi @myrmarachne, opened a small PR to allow excluding weekends for `PeriodicEvent` object.

For example in `demo_scripts/strategies/intraday_strategy.py` just use `CalculateAndPlaceOrdersPeriodicEvent.exclude_weekends()` in line `99`.