### PR TITLE
Fixed aggregation of bars in PresetDataProvider

### DIFF
--- a/qf_lib/data_providers/data_provider.py
+++ b/qf_lib/data_providers/data_provider.py
@@ -282,13 +282,11 @@ class DataProvider(object, metaclass=ABCMeta):
 
     @staticmethod
     def _compute_start_date(nr_of_bars_needed: int, end_date: datetime, frequency: Frequency):
-        if frequency <= Frequency.DAILY:
-            nr_of_days_to_go_back = math.ceil(nr_of_bars_needed * (365 / 252) + 10)
-        else:
-            days_per_year = Frequency.DAILY.occurrences_in_year
-            bars_per_year = frequency.occurrences_in_year
-            bars_per_day = int(bars_per_year / days_per_year)
-            nr_of_days_to_go_back = math.ceil(nr_of_bars_needed / bars_per_day + 1)
+        calendar_to_business_day_factor = 365 / 252
+        frequency_multiplier = Frequency.DAILY.value / frequency.value
+        margin = 10 if frequency <= Frequency.DAILY else 1
+        nr_of_days_to_go_back = math.ceil(
+            nr_of_bars_needed * frequency_multiplier * calendar_to_business_day_factor) + margin
 
         # In case if the end_date points to saturday, sunday or monday shift it to saturday midnight
         if end_date.weekday() in (0, 5, 6):

--- a/qf_lib/data_providers/data_provider.py
+++ b/qf_lib/data_providers/data_provider.py
@@ -282,11 +282,8 @@ class DataProvider(object, metaclass=ABCMeta):
 
     @staticmethod
     def _compute_start_date(nr_of_bars_needed: int, end_date: datetime, frequency: Frequency):
-        calendar_to_business_day_factor = 365 / 252
-        frequency_multiplier = Frequency.DAILY.value / frequency.value
         margin = 10 if frequency <= Frequency.DAILY else 1
-        nr_of_days_to_go_back = math.ceil(
-            nr_of_bars_needed * frequency_multiplier * calendar_to_business_day_factor) + margin
+        nr_of_days_to_go_back = math.ceil(nr_of_bars_needed * 365 / frequency.value) + margin
 
         # In case if the end_date points to saturday, sunday or monday shift it to saturday midnight
         if end_date.weekday() in (0, 5, 6):

--- a/qf_lib/data_providers/preset_data_provider.py
+++ b/qf_lib/data_providers/preset_data_provider.py
@@ -127,9 +127,9 @@ class PresetDataProvider(DataProvider):
         self._check_if_cached_data_available(specific_tickers, fields, start_date, end_date)
         data_array = self._data_bundle.loc[start_date:end_date, specific_tickers, fields]
 
-        # Data aggregation (allowed only for the Intraday Data and in case if more then 1 data point is found)
-        if frequency < self._frequency and len(data_array[DATES]) > 0:
-            data_array = self._aggregate_intraday_data(data_array, start_date, end_date, fields, frequency)
+        # Data aggregation (allowed only for the Intraday Data and in case if more than 1 data point is found)
+        if frequency < self._frequency and data_array.shape[0] > 0:
+            data_array = self._aggregate_intraday_data(data_array, fields, frequency)
 
         normalized_result = normalize_data_array(
             data_array, specific_tickers, fields, got_single_date, got_single_ticker, got_single_field,
@@ -153,43 +153,31 @@ class PresetDataProvider(DataProvider):
         fields, got_single_field = convert_to_list(fields, PriceField)
         got_single_date = nr_of_bars == 1
 
-        data_bundle = self._data_bundle
+        data_bundle = self._data_bundle.loc[:end_date, specific_tickers, fields].dropna(DATES, how='all')
 
-        # Data aggregation (allowed only for the Intraday Data and in case if more then 1 data point is found)
-        if frequency < self._frequency and len(data_bundle[DATES]) > 0:
-            data_bundle = self._aggregate_intraday_data_helper(data_bundle, frequency, fields)
+        if self._frequency == frequency:
+            self._check_data_availibility(data_bundle, end_date, nr_of_bars, tickers)
+            data_bundle = data_bundle.isel(dates=slice(-nr_of_bars, None))
+        elif frequency < self._frequency and data_bundle.shape[0] > 0:
+            # Data aggregation will happen only for the Intraday Data and in case if more than 1 data point is found
+            bars_len_multiplier = int(
+                ceil(to_offset(frequency.to_pandas_freq()) / to_offset(self._frequency.to_pandas_freq()))
+            )
+            # optimize by selecting only part of data_bundle to be aggregated as aggregation is slow
+            bars_before_aggregation = nr_of_bars * bars_len_multiplier * 1.2
+            self._check_data_availibility(data_bundle, end_date, bars_before_aggregation, tickers)
+            data_bundle = data_bundle.isel(dates=slice(-bars_before_aggregation, None)).dropna(DATES, how='all')
 
-        if frequency == Frequency.DAILY:
-            start_date = self._compute_start_date(nr_of_bars, end_date, frequency)
-        else:
-            start_date = end_date - RelativeDelta(days=14)  # to optimize running time for intraday data
-
-        data_array = data_bundle.loc[start_date:end_date, specific_tickers, fields].dropna(DATES, how='all')
-        data_array = data_array.isel(dates=slice(-nr_of_bars, None))
-
-        missing_bars = nr_of_bars - data_array.shape[0]
-
-        if missing_bars > 0:
-            start_date = self._compute_start_date(missing_bars, start_date, frequency)
-            data_array = data_bundle.loc[start_date:end_date, specific_tickers, fields].dropna(DATES, how='all')
-            data_array = data_array.isel(dates=slice(-nr_of_bars, None))
+            data_bundle = self._aggregate_intraday_data(data_bundle, fields, frequency)
+            data_bundle = data_bundle.isel(dates=slice(-nr_of_bars, None))
 
         normalized_result = normalize_data_array(
-            data_array, specific_tickers, fields, got_single_date, got_single_ticker, got_single_field,
+            data_bundle, specific_tickers, fields, got_single_date, got_single_ticker, got_single_field,
             use_prices_types=True
         )
 
         normalized_result = self._map_normalized_result(normalized_result, tickers_mapping, tickers)
-
-        num_of_dates_available = normalized_result.shape[0]
-        if num_of_dates_available < nr_of_bars:
-            if isinstance(tickers, Ticker):
-                tickers_as_strings = tickers.as_string()
-            else:
-                tickers_as_strings = ", ".join(ticker.as_string() for ticker in tickers)
-            raise ValueError(f"Not enough data points for \ntickers: {tickers_as_strings} \ndate: {end_date}."
-                             f"\n{nr_of_bars} Data points requested, \n{num_of_dates_available} Data points available.")
-
+        self._check_data_availibility(normalized_result, end_date, nr_of_bars, tickers)
         return normalized_result
 
     def get_last_available_price(self, tickers: Union[Ticker, Sequence[Ticker]], frequency: Frequency,
@@ -208,11 +196,6 @@ class PresetDataProvider(DataProvider):
         start_time = end_time - RelativeDelta(days=7)  # 7 days to know if an asset disappears
         data_array = self._data_bundle.loc[start_time:end_time, specific_tickers, [PriceField.Open, PriceField.Close]]
 
-        # Data aggregation (allowed only for the Intraday Data and in case if more then 1 data point is found)
-        if frequency < self._frequency and len(data_array[DATES]) > 0:
-            data_array = self._aggregate_intraday_data_helper(data_array, frequency,
-                                                              [PriceField.Open, PriceField.Close])
-
         # Get the Close price of latest bar if available for all the tickers
         last_close = data_array.isel(dates=slice(-1, None)).loc[:, :, [PriceField.Close]]
         if not last_close.isnull().any():
@@ -222,14 +205,8 @@ class PresetDataProvider(DataProvider):
             normalized_result = self._map_normalized_result(normalized_result, tickers_mapping, tickers)
             return normalized_result
 
-        open_data_array = data_array.loc[:, :, [PriceField.Open]]
-        open_prices = normalize_data_array(open_data_array, specific_tickers, [PriceField.Open], got_single_date=False,
-                                           got_single_ticker=False, got_single_field=True, use_prices_types=True)
-
-        close_data_array = data_array.loc[:, :, [PriceField.Close]]
-        close_prices = normalize_data_array(close_data_array, specific_tickers, [PriceField.Close],
-                                            got_single_date=False,
-                                            got_single_ticker=False, got_single_field=True, use_prices_types=True)
+        open_prices = data_array.loc[:, :, [PriceField.Open]].squeeze(axis=2).to_pandas()
+        close_prices = data_array.loc[:, :, [PriceField.Close]].squeeze(axis=2).to_pandas()
 
         first_indices = [df.first_valid_index().to_pydatetime() for df in [open_prices, close_prices] if
                          df.first_valid_index() is not None]
@@ -344,25 +321,21 @@ class PresetDataProvider(DataProvider):
                 normalized_result = normalized_result.rename(tickers_mapping)
         return normalized_result
 
-    def _aggregate_intraday_data_helper(self, data_array, frequency: Frequency, fields: Sequence[PriceField]):
-        # Data aggregation (allowed only for the Intraday Data and in case if more then 1 data point is found)
-        expected_nr_of_bars = int(ceil(
-            to_offset(frequency.to_pandas_freq()) / to_offset(self._frequency.to_pandas_freq())))
-        data_array = data_array.isel(dates=slice(-expected_nr_of_bars, None))
-        start_date = data_array[DATES][0].values
-        end_date = data_array[DATES][-1].values
-        data_array = self._aggregate_intraday_data(data_array, start_date, end_date, fields, frequency)
-        return data_array
+    def _check_data_availibility(self, data_bundle, end_date, nr_of_bars, tickers):
+        if data_bundle.shape[0] < nr_of_bars:
+            tickers_as_strings = ", ".join(ticker.as_string() for ticker in tickers)
+            raise ValueError(f"Not enough data points for tickers: {tickers_as_strings}, date: {end_date}. "
+                             f"{nr_of_bars} Data points requested, {data_bundle.shape[0]} points available. "
+                             f"Number of bars requested will increase data aggregation is needed.")
 
-    def _aggregate_intraday_data(self, data_array, start_date: datetime, end_date: datetime, fields,
-                                 frequency: Frequency):
+    def _aggregate_intraday_data(self, data_array, fields, frequency: Frequency):
         """
         Function, which aggregates the intraday data array for various dates and returns a new data array with data
         sampled with the given frequency.
         """
         prices_list = []
         for field in fields:
-            prices = data_array.loc[start_date:end_date, :, field].to_series().groupby(
+            prices = data_array.loc[:, :, field].to_series().groupby(
                 [pd.Grouper(freq=frequency.to_pandas_freq(), level=0, label="left", origin="start_day"),
                  pd.Grouper(level=1)])
 

--- a/qf_lib/data_providers/preset_data_provider.py
+++ b/qf_lib/data_providers/preset_data_provider.py
@@ -14,9 +14,9 @@
 
 from datetime import datetime
 from typing import Union, Sequence, Any, Set, Type, Dict, FrozenSet, Optional, Tuple
+
 import pandas as pd
-from numpy import nan, ceil
-from pandas._libs.tslibs import to_offset
+from numpy import nan
 
 from qf_lib.common.enums.expiration_date_field import ExpirationDateField
 from qf_lib.common.enums.frequency import Frequency
@@ -31,8 +31,8 @@ from qf_lib.containers.futures.future_tickers.future_ticker import FutureTicker
 from qf_lib.containers.qf_data_array import QFDataArray
 from qf_lib.containers.series.prices_series import PricesSeries
 from qf_lib.containers.series.qf_series import QFSeries
-from qf_lib.data_providers.helpers import normalize_data_array
 from qf_lib.data_providers.data_provider import DataProvider
+from qf_lib.data_providers.helpers import normalize_data_array
 
 
 class PresetDataProvider(DataProvider):

--- a/qf_lib/tests/unit_tests/data_providers/test_preset_data_provider.py
+++ b/qf_lib/tests/unit_tests/data_providers/test_preset_data_provider.py
@@ -414,4 +414,3 @@ class TestPresetDataProvider(unittest.TestCase):
                          data_monthly.loc[datetime(2016, 12, 31), PriceField.Close])
         self.assertEqual(data.loc[datetime(2016, 12, 1):datetime(2016, 12, 30), PriceField.Volume].sum(),
                          data_monthly.loc[datetime(2016, 12, 31), PriceField.Volume])
-

--- a/qf_lib/tests/unit_tests/data_providers/test_preset_data_provider.py
+++ b/qf_lib/tests/unit_tests/data_providers/test_preset_data_provider.py
@@ -348,3 +348,70 @@ class TestPresetDataProvider(unittest.TestCase):
                          data_60_min.loc[datetime(2017, 1, 2, 13), PriceField.Close])
         self.assertEqual(data.loc[datetime(2017, 1, 2, 13, 30):datetime(2017, 1, 2, 13, 55), PriceField.Volume].sum(),
                          data_60_min.loc[datetime(2017, 1, 2, 13), PriceField.Volume])
+
+    def test_get_historical_price_minute_data_aggregation(self):
+        no_of_bars = 3
+
+        data = self.data_provider_min_1.historical_price(
+            self.ticker, PriceField.ohlcv(), no_of_bars * 60, datetime(2017, 1, 2, 15), Frequency.MIN_1)
+
+        data_5_min = self.data_provider_min_1.historical_price(
+            self.ticker, PriceField.ohlcv(), no_of_bars, datetime(2017, 1, 2, 15), Frequency.MIN_5)
+        data_15_min = self.data_provider_min_1.historical_price(
+            self.ticker, PriceField.ohlcv(), no_of_bars, datetime(2017, 1, 2, 15), Frequency.MIN_15)
+        data_60_min = self.data_provider_min_1.historical_price(
+            self.ticker, PriceField.ohlcv(), no_of_bars, datetime(2017, 1, 2, 15), Frequency.MIN_60)
+
+        self.assertEqual(data_5_min.shape[0], no_of_bars)
+        self.assertEqual(data_15_min.shape[0], no_of_bars)
+        self.assertEqual(data_60_min.shape[0], no_of_bars)
+
+        self.assertEqual(data.loc[datetime(2017, 1, 2, 14, 55), PriceField.Open],
+                         data_5_min.loc[datetime(2017, 1, 2, 14, 55), PriceField.Open])
+        self.assertEqual(data.loc[datetime(2017, 1, 2, 14, 59), PriceField.Close],
+                         data_5_min.loc[datetime(2017, 1, 2, 14, 55), PriceField.Close])
+        self.assertEqual(data.loc[datetime(2017, 1, 2, 14, 55):datetime(2017, 1, 2, 14, 59), PriceField.Volume].sum(),
+                         data_5_min.loc[datetime(2017, 1, 2, 14, 55), PriceField.Volume])
+
+        self.assertEqual(data.loc[datetime(2017, 1, 2, 14, 45), PriceField.Open],
+                         data_15_min.loc[datetime(2017, 1, 2, 14, 45), PriceField.Open])
+        self.assertEqual(data.loc[datetime(2017, 1, 2, 14, 59), PriceField.Close],
+                         data_15_min.loc[datetime(2017, 1, 2, 14, 45), PriceField.Close])
+        self.assertEqual(data.loc[datetime(2017, 1, 2, 14, 45):datetime(2017, 1, 2, 14, 59), PriceField.Volume].sum(),
+                         data_15_min.loc[datetime(2017, 1, 2, 14, 45), PriceField.Volume])
+
+        self.assertEqual(data.loc[datetime(2017, 1, 2, 14, 0), PriceField.Open],
+                         data_60_min.loc[datetime(2017, 1, 2, 14, 0), PriceField.Open])
+        self.assertEqual(data.loc[datetime(2017, 1, 2, 14, 59), PriceField.Close],
+                         data_60_min.loc[datetime(2017, 1, 2, 14, 0), PriceField.Close])
+        self.assertEqual(data.loc[datetime(2017, 1, 2, 14, 0):datetime(2017, 1, 2, 14, 59), PriceField.Volume].sum(),
+                         data_60_min.loc[datetime(2017, 1, 2, 14, 0), PriceField.Volume])
+
+    def test_get_historical_price_days_data_aggregation(self):
+        no_of_bars = 3
+
+        data = self.data_provider_daily.historical_price(
+            self.ticker, PriceField.ohlcv(), no_of_bars * 31, datetime(2017, 1, 2), Frequency.DAILY)
+
+        data_weekly = self.data_provider_daily.historical_price(
+            self.ticker, PriceField.ohlcv(), no_of_bars, datetime(2017, 1, 2), Frequency.WEEKLY)
+        data_monthly = self.data_provider_daily.historical_price(
+            self.ticker, PriceField.ohlcv(), no_of_bars, datetime(2017, 1, 2), Frequency.MONTHLY)
+
+        self.assertEqual(data_weekly.shape[0], no_of_bars)
+        self.assertEqual(data_monthly.shape[0], no_of_bars)
+
+        self.assertEqual(data.loc[datetime(2016, 12, 26), PriceField.Open],
+                         data_weekly.loc[datetime(2017, 1, 1), PriceField.Open])
+        self.assertEqual(data.loc[datetime(2016, 12, 30), PriceField.Close],
+                         data_weekly.loc[datetime(2017, 1, 1), PriceField.Close])
+        self.assertEqual(data.loc[datetime(2016, 12, 26):datetime(2016, 12, 30), PriceField.Volume].sum(),
+                         data_weekly.loc[datetime(2017, 1, 1), PriceField.Volume])
+
+        self.assertEqual(data.loc[datetime(2016, 12, 1), PriceField.Open],
+                         data_monthly.loc[datetime(2016, 12, 31), PriceField.Open])
+        self.assertEqual(data.loc[datetime(2016, 12, 30), PriceField.Close],
+                         data_monthly.loc[datetime(2016, 12, 31), PriceField.Close])
+        self.assertEqual(data.loc[datetime(2016, 12, 1):datetime(2016, 12, 30), PriceField.Volume].sum(),
+                         data_monthly.loc[datetime(2016, 12, 31), PriceField.Volume])
+


### PR DESCRIPTION
Fixed aggregation of bars by removing incorrect method _aggregate_inraday_data_helper. 
Added tests for price aggregation
Simplified and optimized logic of PresetDataProvider
Unified logic of returning timeseries with different frequencies 
Made it possible to run get_historical_price with different frequencies (not only intraday) 
Backtest is now a bit faster: 2:10h instead of 2:30h - for intraday backtest 
