### PR TITLE
Email publisher works with simple strings

### DIFF
--- a/qf_lib/documents_utils/email_publishing/email_publisher.py
+++ b/qf_lib/documents_utils/email_publishing/email_publisher.py
@@ -20,6 +20,7 @@ import emails
 from emails.template import JinjaTemplate as T
 
 from qf_lib.common.utils.logging.qf_parent_logger import qf_logger
+from qf_lib.common.utils.miscellaneous.to_list_conversion import convert_to_list
 from qf_lib.settings import Settings
 from qf_lib.starting_dir import get_starting_dir_abs_path
 
@@ -116,14 +117,17 @@ class EmailPublisher:
                 log_info_strings.append("--> {}".format(attachment))
         if mail_to:
             log_info_strings.append("Mail receipents: ")
+            mail_to, _ = convert_to_list(mail_to, str)
             for receipent in list(mail_to):
                 log_info_strings.append("--> {}".format(receipent))
         if cc:
             log_info_strings.append("CC recepients: ")
+            cc, _ = convert_to_list(cc, str)
             for receipent in list(cc):
                 log_info_strings.append("--> {}".format(receipent))
         if bcc:
             log_info_strings.append("BCC recepients: ")
+            bcc, _ = convert_to_list(bcc, str)
             for receipent in list(bcc):
                 log_info_strings.append("--> {}".format(receipent))
 


### PR DESCRIPTION
if we setup a logger and try to send an email with simple strings as bellow:
```
email_provider.publish(
    mail_to="mateitavis@gmail.com",
    cc="mateitavis@gmail.com",
    bcc="mateitavis@gmail.com",
    subject=test_subject,
    template_path=test_template,
    context={test_context}
)
```
the logger will display the following:
![image](https://user-images.githubusercontent.com/28965189/197532156-d4e2f0b9-8362-40ee-9695-a1871ee2d40e.png)

with the fix, the logger will write the following:
![image](https://user-images.githubusercontent.com/28965189/197532226-e6cf79bb-bbc4-4b13-9c62-5df01602e9c1.png)
