### PR TITLE
Data License - add pricing source parameter

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -138,7 +138,9 @@ jobs:
           pip install flake8==5.0.4 pytest
           pip install coverage
       - name: Upload to Codecov
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:
           files: ./unit_tests.xml, ./data_providers_tests.xml, ./backtesting_tests.xml
           fail_ci_if_error: true

--- a/qf_lib/data_providers/bloomberg_beap_hapi/bloomberg_beap_hapi_data_provider.py
+++ b/qf_lib/data_providers/bloomberg_beap_hapi/bloomberg_beap_hapi_data_provider.py
@@ -153,7 +153,7 @@ class BloombergBeapHapiDataProvider(AbstractPriceDataProvider, TickersUniversePr
     def get_history(self, tickers: Union[BloombergTicker, Sequence[BloombergTicker]], fields: Union[str, Sequence[str]],
                     start_date: datetime, end_date: datetime = None, frequency: Frequency = Frequency.DAILY,
                     universe_creation_time: Optional[datetime] = None, currency: Optional[str] = None,
-                    pricing_source: Optional[str] = None) -> \
+                    pricing_source: Optional[str] = "BGN") -> \
             Union[QFSeries, QFDataFrame, QFDataArray]:
         """
         Gets historical data from Bloomberg HAPI from the (start_date - end_date) time range.
@@ -342,7 +342,7 @@ class BloombergBeapHapiDataProvider(AbstractPriceDataProvider, TickersUniversePr
 
     def get_current_values(self, tickers: Union[BloombergTicker, Sequence[BloombergTicker]],
                            fields: Union[str, Sequence[str]], universe_creation_time: datetime = None,
-                           fields_overrides: Optional[List[Tuple]] = None, pricing_source: Optional[str] = None) -> \
+                           fields_overrides: Optional[List[Tuple]] = None, pricing_source: Optional[str] = "BGN") -> \
             Union[None, float, str, List, QFSeries, QFDataFrame]:
         """
         Gets from the Bloomberg HAPI the current values of fields for given tickers.

--- a/qf_lib/data_providers/bloomberg_beap_hapi/bloomberg_beap_hapi_request_provider.py
+++ b/qf_lib/data_providers/bloomberg_beap_hapi/bloomberg_beap_hapi_request_provider.py
@@ -56,7 +56,8 @@ class BloombergBeapHapiRequestsProvider:
 
         self.logger = qf_logger.getChild(self.__class__.__name__)
 
-    def create_request(self, request_id: str, universe_url: str, fieldlist_url: str):
+    def create_request(self, request_id: str, universe_url: str, fieldlist_url: str,
+                       pricing_source: Optional[str] = None):
         """
         Method to create hapi request and get request address URL
 
@@ -68,6 +69,9 @@ class BloombergBeapHapiRequestsProvider:
             URL address of the universe
         fieldlist_url: str
             URL address of the fields
+        pricing_source: Optional[str]
+            Allows a user to specify a pricing source that is applied to all financial instruments in the request
+            universe. By default equals to 'BGN'.
         """
         request_payload = {
             '@type': 'DataRequest',
@@ -87,7 +91,8 @@ class BloombergBeapHapiRequestsProvider:
             },
             'pricingSourceOptions': {
                 '@type': 'DataPricingSourceOptions',
-                'prefer': {'mnemonic': 'BGN'}
+                'exclusive': True,
+                'prefer': {'mnemonic': pricing_source or 'BGN'}
             }
         }
 
@@ -96,7 +101,8 @@ class BloombergBeapHapiRequestsProvider:
         self._create_request_common(request_id, request_payload)
 
     def create_request_history(self, request_id: str, universe_url: str, fieldlist_url: str, start_date: datetime,
-                               end_date: datetime, frequency: Frequency, currency: Optional[str] = None):
+                               end_date: datetime, frequency: Frequency, currency: Optional[str] = None,
+                               pricing_source: Optional[str] = None):
         """
         Method to create hapi history request
 
@@ -116,6 +122,9 @@ class BloombergBeapHapiRequestsProvider:
             Frequency of data
         currency: Optional[str]
             currency which should be used to make the requests
+        pricing_source: Optional[str]
+            Allows a user to specify a pricing source that is applied to all financial instruments in the request
+            universe. By default equals to 'BGN'.
         """
         request_payload = {
             '@type': 'HistoryRequest',
@@ -142,7 +151,7 @@ class BloombergBeapHapiRequestsProvider:
             },
             'pricingSourceOptions': {
                 '@type': 'HistoryPricingSourceOptions',
-                'exclusive': True
+                'prefer': {'mnemonic': pricing_source or 'BGN'}
             }
         }
 

--- a/qf_lib/data_providers/bloomberg_beap_hapi/bloomberg_beap_hapi_request_provider.py
+++ b/qf_lib/data_providers/bloomberg_beap_hapi/bloomberg_beap_hapi_request_provider.py
@@ -57,7 +57,7 @@ class BloombergBeapHapiRequestsProvider:
         self.logger = qf_logger.getChild(self.__class__.__name__)
 
     def create_request(self, request_id: str, universe_url: str, fieldlist_url: str,
-                       pricing_source: Optional[str] = None):
+                       pricing_source: Optional[str] = "BGN"):
         """
         Method to create hapi request and get request address URL
 
@@ -92,7 +92,7 @@ class BloombergBeapHapiRequestsProvider:
             'pricingSourceOptions': {
                 '@type': 'DataPricingSourceOptions',
                 'exclusive': True,
-                'prefer': {'mnemonic': pricing_source or 'BGN'}
+                'prefer': {'mnemonic': pricing_source}
             }
         }
 
@@ -102,7 +102,7 @@ class BloombergBeapHapiRequestsProvider:
 
     def create_request_history(self, request_id: str, universe_url: str, fieldlist_url: str, start_date: datetime,
                                end_date: datetime, frequency: Frequency, currency: Optional[str] = None,
-                               pricing_source: Optional[str] = None):
+                               pricing_source: Optional[str] = "BGN"):
         """
         Method to create hapi history request
 
@@ -151,7 +151,7 @@ class BloombergBeapHapiRequestsProvider:
             },
             'pricingSourceOptions': {
                 '@type': 'HistoryPricingSourceOptions',
-                'prefer': {'mnemonic': pricing_source or 'BGN'}
+                'prefer': {'mnemonic': pricing_source}
             }
         }
 


### PR DESCRIPTION
Adding pricing_source parameter to get_history and get_current_values functions in BloombergBeapHapiDataProvider. Default pricing source is always BGN.