### PR TITLE
Currencies in backtest

### DIFF
--- a/qf_lib/backtesting/broker/backtest_broker.py
+++ b/qf_lib/backtesting/broker/backtest_broker.py
@@ -20,6 +20,7 @@ from qf_lib.backtesting.execution_handler.execution_handler import ExecutionHand
 from qf_lib.backtesting.order.order import Order
 from qf_lib.backtesting.portfolio.portfolio import Portfolio
 from qf_lib.backtesting.portfolio.position import Position
+from qf_lib.common.enums.currency import Currency
 
 
 class BacktestBroker(Broker):
@@ -31,6 +32,9 @@ class BacktestBroker(Broker):
 
     def get_portfolio_value(self) -> Optional[float]:
         return self.portfolio.net_liquidation
+
+    def get_portfolio_value_in_currency(self, currency: Currency):
+        return self.portfolio.net_liquidation_in_currency(currency)
 
     def get_positions(self) -> List[Position]:
         return list(self.portfolio.open_positions_dict.values())

--- a/qf_lib/backtesting/broker/broker.py
+++ b/qf_lib/backtesting/broker/broker.py
@@ -18,6 +18,7 @@ from typing import List, Optional, Sequence
 from qf_lib.backtesting.contract.contract_to_ticker_conversion.base import ContractTickerMapper
 from qf_lib.backtesting.order.order import Order
 from qf_lib.backtesting.portfolio.position import Position
+from qf_lib.common.enums.currency import Currency
 
 
 class Broker(metaclass=ABCMeta):
@@ -38,6 +39,10 @@ class Broker(metaclass=ABCMeta):
 
     @abstractmethod
     def get_portfolio_value(self) -> float:
+        pass
+
+    @abstractmethod
+    def get_portfolio_value_in_currency(self, currency: Currency) -> float:
         pass
 
     @abstractmethod

--- a/qf_lib/backtesting/portfolio/portfolio.py
+++ b/qf_lib/backtesting/portfolio/portfolio.py
@@ -19,16 +19,19 @@ from qf_lib.backtesting.portfolio.backtest_position import BacktestPosition, Bac
 from qf_lib.backtesting.portfolio.position_factory import BacktestPositionFactory
 from qf_lib.backtesting.portfolio.transaction import Transaction
 from qf_lib.backtesting.portfolio.utils import split_transaction_if_needed
+from qf_lib.common.enums.currency import Currency
 from qf_lib.common.tickers.tickers import Ticker
 from qf_lib.common.utils.dateutils.timer import Timer
 from qf_lib.common.utils.logging.qf_parent_logger import qf_logger
 from qf_lib.containers.dataframe.qf_dataframe import QFDataFrame
+from qf_lib.containers.futures.future_tickers.exchange_rate_ticker import CurrencyExchangeTicker
 from qf_lib.containers.series.prices_series import PricesSeries
 from qf_lib.containers.series.qf_series import QFSeries
 
 
 class Portfolio:
-    def __init__(self, data_handler: DataHandler, initial_cash: float, timer: Timer):
+    def __init__(self, data_handler: DataHandler, initial_cash: float, timer: Timer,
+                 currency: Currency, currency_exchange_tickers: List[CurrencyExchangeTicker]):
         """
         On creation, the Portfolio object contains no positions and all values are "reset" to the initial
         cash, with no PnL.
@@ -36,6 +39,8 @@ class Portfolio:
         self.initial_cash = initial_cash
         self.data_handler = data_handler
         self.timer = timer
+        self.portfolio_currency = currency
+        self.currency_exchange_tickers = currency_exchange_tickers
 
         self.net_liquidation = initial_cash
         """ Cash value includes futures P&L + stock value + securities options value + bond value + fund value. """
@@ -64,6 +69,22 @@ class Portfolio:
 
         self.logger = qf_logger.getChild(self.__class__.__name__)
 
+    def get_currency_ticker(self, from_currency: Currency, to_currency: Currency) -> CurrencyExchangeTicker:
+        for ticker in self.currency_exchange_tickers:
+            if ticker.from_currency == from_currency and ticker.to_currency == to_currency:
+                return ticker
+
+    def current_exchange_rate(self, currency: Currency) -> float:
+        """Last available exchange rate from the specified currency to the portfolio currency."""
+        if currency != self.portfolio_currency:
+            currency_ticker = self.get_currency_ticker(from_currency=currency, to_currency=self.portfolio_currency)
+            return self.data_handler.get_last_available_price(tickers=currency_ticker)/currency_ticker.point_value
+        return 1.
+
+    def net_liquidation_in_currency(self, currency: Currency) -> float:
+        """Converts the current net liquidation from the portfolio currency into the specified currency"""
+        return self.net_liquidation/self.current_exchange_rate(currency)
+
     def transact_transaction(self, transaction: Transaction):
         """
         Adjusts positions to account for a transaction.
@@ -90,7 +111,7 @@ class Portfolio:
                 new_position = self._create_new_position(remaining_transaction)
                 transaction_cost += new_position.transact_transaction(remaining_transaction)
 
-        self.current_cash += transaction_cost
+        self.current_cash += transaction_cost*self.current_exchange_rate(transaction.ticker.currency)
 
     def update(self, record=False):
         """
@@ -111,8 +132,10 @@ class Portfolio:
             position.update_price(bid_price=security_price, ask_price=security_price)
             position_value = position.market_value()
             position_exposure = position.total_exposure()
-            self.net_liquidation += position_value
-            self.gross_exposure_of_positions += abs(position_exposure)
+            current_exchange_rate = self.current_exchange_rate(ticker.currency)
+            self.net_liquidation += position_value*current_exchange_rate
+
+            self.gross_exposure_of_positions += abs(position_exposure)*current_exchange_rate
             if record:
                 current_positions[ticker] = BacktestPositionSummary(position)
 

--- a/qf_lib/common/enums/currency.py
+++ b/qf_lib/common/enums/currency.py
@@ -1,0 +1,28 @@
+from enum import Enum
+
+
+class Currency(Enum):
+    """
+    Enum which denotes different currencies.
+    """
+
+    USD = "U.S. Dollar"
+    """United States Dollar"""
+    EUR = "Euro"
+    """Euro"""
+    CHF = "Swiss Franc"
+    """Swiss Franc"""
+    GBP = "British Pound"
+    """Sterling"""
+    JPY = "Japanese Yen"
+    """Japanese Yen"""
+    CNY = "Renminbi"
+    """Chinese Yuan"""
+    AUD = "Australian Dollar"
+    """Australian Dollar"""
+    CAD = "Canadian Dollar"
+    """Canadian Dollar"""
+    HKD = "Hong Kong Dollar"
+    """Hong Kong Dollar"""
+    KRW = "South Korean Won"
+    """South Korean Won"""

--- a/qf_lib/common/tickers/tickers.py
+++ b/qf_lib/common/tickers/tickers.py
@@ -16,6 +16,7 @@ from abc import abstractmethod, ABCMeta
 from functools import total_ordering
 from typing import Union, Sequence
 
+from qf_lib.common.enums.currency import Currency
 from qf_lib.common.enums.quandl_db_type import QuandlDBType
 from qf_lib.common.enums.security_type import SecurityType
 from qf_lib.common.utils.logging.qf_parent_logger import qf_logger
@@ -117,8 +118,10 @@ class BloombergTicker(Ticker):
         size of the contract as given by the ticker's Data Provider. Used mostly by tickers of security_type FUTURE and
         by default equals 1.
     """
-    def __init__(self, ticker: str, security_type: SecurityType = SecurityType.STOCK, point_value: int = 1):
+    def __init__(self, ticker: str, security_type: SecurityType = SecurityType.STOCK, 
+                 point_value: int = 1, currency: Currency = None):
         super().__init__(ticker, security_type, point_value)
+        self.currency = currency
 
     @classmethod
     def from_string(cls, ticker_str: Union[str, Sequence[str]], security_type: SecurityType = SecurityType.STOCK,
@@ -130,6 +133,9 @@ class BloombergTicker(Ticker):
             return BloombergTicker(ticker_str, security_type, point_value)
         else:
             return [BloombergTicker(t, security_type, point_value) for t in ticker_str]
+
+    def set_currency(self, currency: Currency):
+        self.currency = currency
 
 
 class PortaraTicker(Ticker):

--- a/qf_lib/containers/futures/future_tickers/bloomberg_future_ticker.py
+++ b/qf_lib/containers/futures/future_tickers/bloomberg_future_ticker.py
@@ -16,6 +16,7 @@ from typing import Type
 
 from pandas import to_datetime
 
+from qf_lib.common.enums.currency import Currency
 from qf_lib.common.enums.expiration_date_field import ExpirationDateField
 from qf_lib.common.enums.security_type import SecurityType
 from qf_lib.common.tickers.tickers import BloombergTicker, Ticker
@@ -61,11 +62,13 @@ class BloombergFutureTicker(FutureTicker, BloombergTicker):
         DataProvider get_futures_chain_tickers function.
     """
     def __init__(self, name: str, family_id: str, N: int, days_before_exp_date: int, point_value: int = 1,
-                 designated_contracts: str = "FGHJKMNQUVXZ", security_type: SecurityType = SecurityType.FUTURE):
+                 designated_contracts: str = "FGHJKMNQUVXZ", security_type: SecurityType = SecurityType.FUTURE,
+                 currency: Currency = Currency.USD):
         if not len(designated_contracts) > 0:
             raise ValueError("At least one month code should be provided.")
 
-        super().__init__(name, family_id, N, days_before_exp_date, point_value, designated_contracts, security_type)
+        super().__init__(name, family_id, N, days_before_exp_date, point_value,
+                         designated_contracts, security_type, currency)
 
     def get_active_ticker(self) -> BloombergTicker:
         """ Returns the active ticker. """
@@ -89,7 +92,8 @@ class BloombergFutureTicker(FutureTicker, BloombergTicker):
         designated_contracts = futures_chain_tickers_series.index[
             futures_chain_tickers_series.index.map(lambda t: bool(re.search(f"^{contracts_pattern}$", t.as_string())))]
         futures_chain_tickers_series = futures_chain_tickers_series.loc[designated_contracts]
-
+        for t in futures_chain_tickers_series.index:
+            t.set_currency(self.currency)
         futures_chain_tickers = QFSeries(futures_chain_tickers_series.index, futures_chain_tickers_series.values)
         futures_chain_tickers.index = to_datetime(futures_chain_tickers.index)
         return futures_chain_tickers

--- a/qf_lib/containers/futures/future_tickers/exchange_rate_ticker.py
+++ b/qf_lib/containers/futures/future_tickers/exchange_rate_ticker.py
@@ -1,0 +1,16 @@
+from typing import Sequence, Union
+from qf_lib.common.enums.security_type import SecurityType
+from qf_lib.common.tickers.tickers import BloombergTicker
+
+
+class CurrencyExchangeTicker(BloombergTicker):
+
+    def __init__(self, ticker: str, from_currency: str, to_currency: str, point_value: int = 1, security_type: SecurityType = SecurityType.FX):
+        super().__init__(ticker, security_type, point_value)
+        self.from_currency = from_currency
+        self.to_currency = to_currency
+
+    def from_string(cls, ticker_str: Union[str, Sequence[str]], security_type: SecurityType = SecurityType.FX,
+                    point_value: int = 1) -> Union["CurrencyExchangeTicker", Sequence["CurrencyExchangeTicker"]]:
+        if isinstance(ticker_str, str):
+            return CurrencyExchangeTicker(ticker_str, security_type, point_value)

--- a/qf_lib/containers/futures/future_tickers/future_ticker.py
+++ b/qf_lib/containers/futures/future_tickers/future_ticker.py
@@ -67,13 +67,15 @@ class FutureTicker(Ticker, metaclass=abc.ABCMeta):
         DataProvider get_futures_chain_tickers function.
     """
     def __init__(self, name: str, family_id: str, N: int, days_before_exp_date: int, point_value: int = 1,
-                 designated_contracts: Optional[str] = None, security_type: SecurityType = SecurityType.FUTURE):
+                 designated_contracts: Optional[str] = None, security_type: SecurityType = SecurityType.FUTURE,
+                 currency: str = "USD"):
         super().__init__(family_id, security_type, point_value)
         self._name = name
         self.family_id = family_id
         self.point_value = point_value
         self.N = N
         self.designated_contracts = designated_contracts
+        self.currency = currency
 
         self._days_before_exp_date = days_before_exp_date
 


### PR DESCRIPTION
Introducing currencies in the backtest:

- Each ticker and future contract now has a designated currency parameter.
- Backtest porfolio has a designated currency.
- Transactions are transacted in the ticker currency and the net liquidation of the portfolio is recorded in the portfolio currency by converting transaction costs and P/L using a set of currency exchange tickers.