### PR TITLE
Update blpapi index and version

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -40,7 +40,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install -e ".[blpapi]" --extra-index-url https://bcms.bloomberg.com/pip/simple/
+        pip install -e ".[blpapi]" --extra-index-url https://blpapi.bloomberg.com/repository/releases/python/simple
         pip install --force-reinstall MarkupSafe==2.0.1
         pip install flake8==5.0.4 pytest
         pip install coverage
@@ -67,7 +67,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -e ".[blpapi]" --extra-index-url https://bcms.bloomberg.com/pip/simple/
+          pip install -e ".[blpapi]" --extra-index-url https://blpapi.bloomberg.com/repository/releases/python/simple
           pip install --force-reinstall MarkupSafe==2.0.1
           pip install flake8==5.0.4 pytest
           pip install coverage
@@ -95,7 +95,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -e ".[blpapi]" --extra-index-url https://bcms.bloomberg.com/pip/simple/
+          pip install -e ".[blpapi]" --extra-index-url https://blpapi.bloomberg.com/repository/releases/python/simple
           pip install --force-reinstall MarkupSafe==2.0.1
           pip install flake8==5.0.4 pytest
           pip install coverage

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ setup(
         "documentation": ["autodocsumm==0.2.9", "sphinx_rtd_theme==1.2.0", "Sphinx==5.0"],
         "interactive brokers": ["ibapi"],
         "bloomberg_beap_hapi": ["PyJWT>=0.2.3,<2.0.0", "retrying>=1.3.3", "beap-lib==0.0.1"],
-        "blpapi": ["blpapi>=3.16.2,<=3.21.0"],
+        "blpapi": ["blpapi==3.21.0"],
         "quandl": ["quandl>=3.6.1,<=3.7.0"],
     },
     keywords='quantitative finance backtester',

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ setup(
         "documentation": ["autodocsumm==0.2.9", "sphinx_rtd_theme==1.2.0", "Sphinx==5.0"],
         "interactive brokers": ["ibapi"],
         "bloomberg_beap_hapi": ["PyJWT>=0.2.3,<2.0.0", "retrying>=1.3.3", "beap-lib==0.0.1"],
-        "blpapi": ["blpapi>=3.16.2,<=3.20.1"],
+        "blpapi": ["blpapi>=3.16.2,<=3.21.0"],
         "quandl": ["quandl>=3.6.1,<=3.7.0"],
     },
     keywords='quantitative finance backtester',


### PR DESCRIPTION
Blpapi index has changed from https://bcms.bloomberg.com/pip/simple/ to https://blpapi.bloomberg.com/repository/releases/python/simple. Only version lower than 3.21.0 available in the new index is 3.16.5, so the blpapi has been updated to 3.21.0.