### PR TITLE
Update arch version in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,5 +14,5 @@ cvxopt>=1.2.7,<=1.3.2
 openpyxl>=3.0.7,<=3.0.9
 WeasyPrint==52.5
 Jinja2==2.11.3
-arch==4.19
+arch==5.4
 requests>=2.25.1,<=2.31.0


### PR DESCRIPTION
wheels for arch 4.19 don't support Python 3.11, upgrade to 5.4 which is the minimum version that supports Python 3.11