### PR TITLE
Add get_tickers_universe_with_weights to BloombergDataProvider

### DIFF
--- a/qf_lib/data_providers/bloomberg/helpers.py
+++ b/qf_lib/data_providers/bloomberg/helpers.py
@@ -124,7 +124,6 @@ def get_response_events(session):
 
 
 def check_security_data_for_errors(security_data):
-    logger = qf_logger.getChild(__name__)
     if security_data.hasElement(FIELD_EXCEPTIONS):
         field_exceptions = security_data.getElement(FIELD_EXCEPTIONS)
         if field_exceptions.numValues() > 0:

--- a/qf_lib/data_providers/bloomberg/helpers.py
+++ b/qf_lib/data_providers/bloomberg/helpers.py
@@ -19,7 +19,6 @@ import numpy as np
 from blpapi import DataType
 
 from qf_lib.common.enums.frequency import Frequency
-from qf_lib.common.utils.logging.qf_parent_logger import qf_logger
 from qf_lib.data_providers.bloomberg.bloomberg_names import SECURITIES, SECURITY, FIELDS, RESPONSE_ERROR, SECURITY_DATA, \
     BAR_DATA, FIELD_EXCEPTIONS, SECURITY_ERROR
 from qf_lib.data_providers.bloomberg.exceptions import BloombergError

--- a/qf_lib/data_providers/bloomberg/helpers.py
+++ b/qf_lib/data_providers/bloomberg/helpers.py
@@ -129,12 +129,10 @@ def check_security_data_for_errors(security_data):
         field_exceptions = security_data.getElement(FIELD_EXCEPTIONS)
         if field_exceptions.numValues() > 0:
             error_message = "Response contains field exceptions:\n" + str(security_data)
-            logger.error(error_message)
             raise BloombergError(error_message)
 
     if security_data.hasElement(SECURITY_ERROR):
         error_message = "Response contains security error:\n" + str(security_data)
-        logger.error(error_message)
         raise BloombergError(error_message)
 
 

--- a/qf_lib/tests/unit_tests/data_providers/bloomberg/config.py
+++ b/qf_lib/tests/unit_tests/data_providers/bloomberg/config.py
@@ -157,6 +157,12 @@ REF_DATA_SERVICE_URI = """<?xml version="1.0" encoding="UTF-8" ?>\
         <element name="LAST_PRICE" type="Float64"  />\
         <element name="PX_LAST"    type="Float64"  />\
         <element name="NAME"    type="String"  />\
+        <element name="INDEX_MEMBERS_WEIGHTS"    type="IndexMember" minOccurs="0" maxOccurs="unbounded"  />\
+    </sequenceType>\
+    <sequenceType name="IndexMember">\
+      <description>The contents of this type depends on the response</description>\
+        <element name="Index Member" type="String"  />\
+        <element name="Weight"    type="Float64"  />\
     </sequenceType>\
     <sequenceType name="FieldException">\
       <element name="fieldId"    type="String"/> \

--- a/qf_lib/tests/unit_tests/data_providers/bloomberg/test_bloomberg_data_provider.py
+++ b/qf_lib/tests/unit_tests/data_providers/bloomberg/test_bloomberg_data_provider.py
@@ -1,0 +1,53 @@
+#     Copyright 2016-present CERN – European Organization for Nuclear Research
+#
+#     Licensed under the Apache License, Version 2.0 (the "License");
+#     you may not use this file except in compliance with the License.
+#     You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#     Unless required by applicable law or agreed to in writing, software
+#     distributed under the License is distributed on an "AS IS" BASIS,
+#     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#     See the License for the specific language governing permissions and
+#     limitations under the License.
+from unittest import TestCase
+from unittest.mock import patch
+
+from numpy import nan
+
+from qf_lib.common.tickers.tickers import BloombergTicker
+from qf_lib.containers.dataframe.qf_dataframe import QFDataFrame
+from qf_lib.data_providers import BloombergDataProvider
+from qf_lib.data_providers.bloomberg.reference_data_provider import ReferenceDataProvider
+from qf_lib.tests.unit_tests.config.test_settings import get_test_settings
+
+
+class TestBloombergDataProvider(TestCase):
+
+    @patch('qf_lib.data_providers.bloomberg.bloomberg_data_provider.blpapi')
+    def setUp(self, blpapi_mock) -> None:
+        self.bbg_provider = BloombergDataProvider(get_test_settings())
+
+    @patch.object(ReferenceDataProvider, "get")
+    def test_get_tabular_data__incorrect_field(self, get_mock):
+        get_mock.return_value = QFDataFrame.from_dict({'PX_LAST': {BloombergTicker('TPX Index'): 2797.52}})
+        with self.assertRaises(ValueError):
+            self.bbg_provider.get_tabular_data(BloombergTicker('TPX Index'), "PX_LAST")
+
+    @patch.object(ReferenceDataProvider, "get")
+    def test_get_tabular_data(self, get_mock):
+        get_mock.return_value = QFDataFrame.from_dict({'INDEX_MEMBERS_WEIGHTS': {
+            BloombergTicker('TPX Index'): [{'Index Member': 'A US', 'Weight': 0.05},
+                                           {'Index Member': 'B US', 'Weight': 0.03}, ]}})
+
+        result = self.bbg_provider.get_tabular_data(BloombergTicker('TPX Index'), "INDEX_MEMBERS_WEIGHTS")
+        expected = [{"Index Member": "A US", "Weight": 0.05}, {"Index Member": "B US", "Weight": 0.03}]
+        self.assertCountEqual(result, expected)
+
+    @patch.object(ReferenceDataProvider, "get")
+    def test_get_tabular_data__incorrect_ticker(self, get_mock):
+        get_mock.return_value = QFDataFrame.from_dict({'INDEX_MEMBERS_WEIGHTS': {BloombergTicker('TPXa Index'): nan}})
+        result = self.bbg_provider.get_tabular_data(BloombergTicker('TPX Index'), "PX_LAST")
+        expected = []
+        self.assertCountEqual(result, expected)

--- a/qf_lib/tests/unit_tests/data_providers/bloomberg/test_reference_data_provider.py
+++ b/qf_lib/tests/unit_tests/data_providers/bloomberg/test_reference_data_provider.py
@@ -253,3 +253,38 @@ class TestReferenceDataProvider(TestCase):
         data_provider.logger = Mock()
         data_provider.get([BloombergTicker("AAPL US Equity")], ["PX_LAST"])
         data_provider.logger.error.assert_called_once()
+
+    def test_get_tabular_data__non_tabular_field(self):
+        session = Mock()
+        session.getService.return_value.createRequest.return_value = Request()
+        event = createEvent(blpapi.Event.RESPONSE)
+
+        schema = self.ref_data_service.getOperation(
+            self.request_name
+        ).getResponseDefinitionAt(0)
+
+        formatter = appendMessage(event, schema)
+        content = {
+            "securityData": [
+                {
+                    "security": "Test Index",
+                    "sequenceNumber": 0,
+                    "fieldData": {
+                        "INDEX_MEMBERS_WEIGHTS": [
+                            {"Index Member": "A US", "Weight": 0.01},
+                            {"Index Member": "B US", "Weight": 0.02}
+                        ],
+                    },
+                }
+            ]
+        }
+        formatter.formatMessageDict(content)
+        session.nextEvent.return_value = event
+
+        data_provider = ReferenceDataProvider(session)
+        result = data_provider.get([BloombergTicker("Test Index")], ["INDEX_MEMBERS_WEIGHTS"])
+        expected = QFDataFrame(data={"INDEX_MEMBERS_WEIGHTS": [[{"Index Member": "A US", "Weight": 0.01},
+                                                                {"Index Member": "B US", "Weight": 0.02}]]},
+                               index=[BloombergTicker("Test Index")])
+        self.assertEqual(result.shape, expected.shape)
+        self.assertCountEqual(result.iloc[0,0], expected.iloc[0,0])

--- a/qf_lib/tests/unit_tests/data_providers/bloomberg/test_reference_data_provider.py
+++ b/qf_lib/tests/unit_tests/data_providers/bloomberg/test_reference_data_provider.py
@@ -287,4 +287,4 @@ class TestReferenceDataProvider(TestCase):
                                                                 {"Index Member": "B US", "Weight": 0.02}]]},
                                index=[BloombergTicker("Test Index")])
         self.assertEqual(result.shape, expected.shape)
-        self.assertCountEqual(result.iloc[0,0], expected.iloc[0,0])
+        self.assertCountEqual(result.iloc[0, 0], expected.iloc[0, 0])


### PR DESCRIPTION
Added the functionality to receive a series of tickers belonging to a given Index. The series is indexed by the tickers with corresponding weights as values.