### PR TITLE
fix: resolve deprecated downcasting behavior in ffill/fillna (closes #248)

### DIFF
--- a/qf_lib/analysis/tearsheets/portfolio_analysis_sheet.py
+++ b/qf_lib/analysis/tearsheets/portfolio_analysis_sheet.py
@@ -355,7 +355,7 @@ class PortfolioAnalysisSheet(AbstractDocument):
 
             pnl_series = QFSeries(
                 data=closed_positions_pnl["Realised PnL"] + open_positions_pnl['Total PnL of open position'],
-                index=time_index).ffill().fillna(0.0)
+                index=time_index).ffill().infer_objects(copy=False).fillna(0.0)
             return_data[title] = pnl_series
 
         return return_data


### PR DESCRIPTION
## What
When generating tearsheets, a `FutureWarning` is raised in `portfolio_analysis_sheet.py` because `ffill()` and `fillna()` perform deprecated silent downcasting on object dtype arrays in pandas 2.x.

## Fix
Added `.infer_objects(copy=False)` between `.ffill()` and `.fillna(0.0)` at line 358 to explicitly handle type inference before filling NaN values, as recommended by the pandas warning message.

Closes #248