### PR TITLE
Add optional Adanos sentiment data provider

### DIFF
--- a/docs/source/data_providers.rst
+++ b/docs/source/data_providers.rst
@@ -14,6 +14,7 @@ data_providers
     futures_data_provider.FuturesDataProvider
     preset_data_provider.PresetDataProvider
     prefetching_data_provider.PrefetchingDataProvider
+    adanos.adanos_data_provider.AdanosDataProvider
     binance_dp.binance_data_provider.BinanceDataProvider
     bloomberg.bloomberg_data_provider.BloombergDataProvider
     bloomberg_dl.bloomberg_dl_data_provider.BloombergDLDataProvider

--- a/qf_lib/data_providers/__init__.py
+++ b/qf_lib/data_providers/__init__.py
@@ -11,6 +11,7 @@
 #     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #     See the License for the specific language governing permissions and
 #     limitations under the License.
+from qf_lib.data_providers.adanos.adanos_data_provider import AdanosDataProvider
 from qf_lib.data_providers.binance_dp.binance_data_provider import BinanceDataProvider
 from qf_lib.data_providers.bloomberg import BloombergDataProvider
 from qf_lib.data_providers.bloomberg_beap_hapi.bloomberg_beap_hapi_data_provider import BloombergBeapHapiDataProvider

--- a/qf_lib/data_providers/adanos/__init__.py
+++ b/qf_lib/data_providers/adanos/__init__.py
@@ -1,0 +1,2 @@
+from qf_lib.data_providers.adanos.adanos_data_provider import AdanosDataProvider
+

--- a/qf_lib/data_providers/adanos/adanos_data_provider.py
+++ b/qf_lib/data_providers/adanos/adanos_data_provider.py
@@ -1,0 +1,200 @@
+#     Copyright 2016-present CERN – European Organization for Nuclear Research
+#
+#     Licensed under the Apache License, Version 2.0 (the "License");
+#     you may not use this file except in compliance with the License.
+#     You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#     Unless required by applicable law or agreed to in writing, software
+#     distributed under the License is distributed on an "AS IS" BASIS,
+#     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#     See the License for the specific language governing permissions and
+#     limitations under the License.
+
+import json
+import os
+from datetime import datetime
+from typing import Any, Dict, Iterable, Optional, Sequence, Set, Type, Union
+from urllib.parse import quote, urlencode
+from urllib.request import Request, urlopen
+
+import pandas as pd
+
+from qf_lib.common.enums.frequency import Frequency
+from qf_lib.common.enums.security_type import SecurityType
+from qf_lib.common.tickers.tickers import Ticker
+from qf_lib.common.utils.dateutils.timer import Timer
+from qf_lib.common.utils.miscellaneous.to_list_conversion import convert_to_list
+from qf_lib.containers.dataframe.qf_dataframe import QFDataFrame
+from qf_lib.containers.qf_data_array import QFDataArray
+from qf_lib.containers.series.qf_series import QFSeries
+from qf_lib.data_providers.data_provider import DataProvider
+from qf_lib.data_providers.helpers import normalize_data_array, tickers_dict_to_data_array
+
+
+class AdanosDataProvider(DataProvider):
+    """
+    Optional DataProvider for Adanos Market Sentiment API stock sentiment data.
+
+    The provider exposes Adanos sentiment values as alternative data fields through the standard get_history()
+    interface. It is intentionally separate from AbstractPriceDataProvider because Adanos does not provide OHLCV
+    prices.
+
+    Parameters
+    ----------
+    api_key
+        Adanos API key. If omitted, the provider reads ADANOS_API_KEY from the environment.
+    source
+        Adanos stock sentiment source: reddit, x, news or polymarket.
+    base_url
+        API base URL. Defaults to https://api.adanos.org.
+    timeout
+        HTTP timeout in seconds.
+
+    Examples
+    --------
+    >>> from qf_lib.common.tickers.tickers import BloombergTicker
+    >>> from qf_lib.data_providers.adanos import AdanosDataProvider
+    >>> provider = AdanosDataProvider(source="reddit")
+    >>> provider.get_history(BloombergTicker("TSLA US Equity"), "sentiment_score", start_date, end_date)
+    """
+
+    DEFAULT_FIELDS = ("sentiment_score", "buzz_score", "mentions")
+    _SOURCE_PATHS = {
+        "reddit": "/reddit/stocks/v1/stock/{ticker}",
+        "x": "/x/stocks/v1/stock/{ticker}",
+        "news": "/news/stocks/v1/stock/{ticker}",
+        "polymarket": "/polymarket/stocks/v1/stock/{ticker}",
+    }
+
+    def __init__(
+            self, api_key: Optional[str] = None, source: str = "reddit", base_url: str = "https://api.adanos.org",
+            timeout: int = 30, timer: Optional[Timer] = None):
+        super().__init__(timer)
+        self.api_key = api_key or os.environ.get("ADANOS_API_KEY")
+        if not self.api_key:
+            raise ValueError("AdanosDataProvider requires an api_key or ADANOS_API_KEY environment variable.")
+
+        source = source.lower()
+        if source not in self._SOURCE_PATHS:
+            raise ValueError("Unsupported Adanos source '{}'. Supported sources are: {}.".format(
+                source, ", ".join(sorted(self._SOURCE_PATHS.keys()))))
+
+        self.source = source
+        self.base_url = base_url.rstrip("/")
+        self.timeout = timeout
+        self.frequency = Frequency.DAILY
+
+    def get_history(
+            self, tickers: Union[Ticker, Sequence[Ticker]], fields: Union[str, Sequence[str]],
+            start_date: datetime, end_date: datetime = None, frequency: Frequency = None,
+            look_ahead_bias: bool = False, **kwargs) -> Union[QFSeries, QFDataFrame, QFDataArray]:
+        """
+        Gets daily Adanos sentiment attributes for the requested stock tickers.
+
+        Supported fields are string field names returned by the Adanos stock sentiment endpoint, for example
+        sentiment_score, buzz_score, mentions, bullish_pct or bearish_pct. If a daily trend series is available in
+        the API response, rows are dated with its daily dates. Otherwise the summary response is returned as one row
+        dated at end_date.
+        """
+        frequency = frequency or self.frequency
+        if frequency != Frequency.DAILY:
+            raise ValueError("AdanosDataProvider supports daily sentiment data only.")
+
+        tickers, got_single_ticker = convert_to_list(tickers, Ticker)
+        fields, got_single_field = convert_to_list(fields, str)
+        if look_ahead_bias:
+            end_date = end_date or self.timer.now()
+        else:
+            end_date = self.get_end_date_without_look_ahead(end_date, frequency)
+        got_single_date = start_date.date() == end_date.date()
+
+        tickers_data_dict = {}
+        for ticker in tickers:
+            self._validate_stock_ticker(ticker)
+            ticker_symbol = self._ticker_to_symbol(ticker)
+            payload = self._get_stock_sentiment(ticker_symbol, start_date, end_date)
+            ticker_df = self._payload_to_dataframe(payload, fields, end_date)
+            if not ticker_df.empty:
+                tickers_data_dict[ticker] = ticker_df
+
+        data_array = tickers_dict_to_data_array(tickers_data_dict, tickers, fields)
+        return normalize_data_array(data_array, tickers, fields, got_single_date, got_single_ticker, got_single_field)
+
+    def supported_ticker_types(self) -> Set[Type[Ticker]]:
+        return {Ticker}
+
+    def _get_stock_sentiment(self, ticker_symbol: str, start_date: datetime, end_date: datetime) -> Dict[str, Any]:
+        path = self._SOURCE_PATHS[self.source].format(ticker=quote(ticker_symbol))
+        params = {
+            "from": start_date.date().isoformat(),
+            "to": end_date.date().isoformat(),
+        }
+        return self._request_json(path, params)
+
+    def _request_json(self, path: str, params: Dict[str, str]) -> Dict[str, Any]:
+        url = "{}{}?{}".format(self.base_url, path, urlencode(params))
+        request = Request(url, headers={
+            "Accept": "application/json",
+            "User-Agent": "qf-lib-adanos-data-provider",
+            "X-API-Key": self.api_key,
+        })
+        with urlopen(request, timeout=self.timeout) as response:
+            return json.loads(response.read().decode("utf-8"))
+
+    @staticmethod
+    def _validate_stock_ticker(ticker: Ticker) -> None:
+        if ticker.security_type != SecurityType.STOCK:
+            raise ValueError("AdanosDataProvider supports stock tickers only.")
+
+    @staticmethod
+    def _ticker_to_symbol(ticker: Ticker) -> str:
+        ticker_str = ticker.as_string().strip()
+        if ticker_str.startswith("$"):
+            ticker_str = ticker_str[1:]
+        return ticker_str.split()[0].upper()
+
+    @classmethod
+    def _payload_to_dataframe(cls, payload: Dict[str, Any], fields: Sequence[str], end_date: datetime) -> QFDataFrame:
+        if payload.get("found") is False:
+            return QFDataFrame(columns=fields)
+
+        daily_rows = cls._daily_rows(payload, fields)
+        if daily_rows:
+            return QFDataFrame.from_dict(daily_rows, orient="index").reindex(columns=fields).sort_index()
+
+        summary_row = cls._row_from_mapping(payload, fields)
+        if all(value is None for value in summary_row.values()):
+            return QFDataFrame(columns=fields)
+
+        return QFDataFrame([summary_row], index=[cls._date_from_value(end_date)]).reindex(columns=fields)
+
+    @classmethod
+    def _daily_rows(cls, payload: Dict[str, Any], fields: Sequence[str]) -> Dict[datetime, Dict[str, Any]]:
+        rows = {}
+        for item in cls._iter_daily_items(payload):
+            if not isinstance(item, dict) or "date" not in item:
+                continue
+
+            date = cls._date_from_value(item["date"])
+            rows[date] = cls._row_from_mapping(item, fields, fallback=payload)
+        return rows
+
+    @staticmethod
+    def _iter_daily_items(payload: Dict[str, Any]) -> Iterable[Dict[str, Any]]:
+        for key in ("daily_trend", "trend_history", "history", "data"):
+            value = payload.get(key)
+            if isinstance(value, list):
+                for item in value:
+                    yield item
+
+    @staticmethod
+    def _row_from_mapping(mapping: Dict[str, Any], fields: Sequence[str],
+                          fallback: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+        fallback = fallback or {}
+        return {field: mapping.get(field, fallback.get(field)) for field in fields}
+
+    @staticmethod
+    def _date_from_value(value: Union[str, datetime]) -> datetime:
+        return pd.Timestamp(value).to_pydatetime().replace(hour=0, minute=0, second=0, microsecond=0)

--- a/qf_lib/tests/unit_tests/data_providers/test_adanos_data_provider.py
+++ b/qf_lib/tests/unit_tests/data_providers/test_adanos_data_provider.py
@@ -1,0 +1,138 @@
+#     Copyright 2016-present CERN – European Organization for Nuclear Research
+#
+#     Licensed under the Apache License, Version 2.0 (the "License");
+#     you may not use this file except in compliance with the License.
+#     You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#     Unless required by applicable law or agreed to in writing, software
+#     distributed under the License is distributed on an "AS IS" BASIS,
+#     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#     See the License for the specific language governing permissions and
+#     limitations under the License.
+
+import os
+from datetime import datetime
+from unittest import TestCase
+from unittest.mock import patch
+
+from qf_lib.common.enums.frequency import Frequency
+from qf_lib.common.enums.security_type import SecurityType
+from qf_lib.common.tickers.tickers import BloombergTicker
+from qf_lib.containers.dataframe.qf_dataframe import QFDataFrame
+from qf_lib.containers.series.qf_series import QFSeries
+from qf_lib.data_providers.adanos import AdanosDataProvider
+from qf_lib.tests.helpers.testing_tools.containers_comparison import assert_dataframes_equal, assert_series_equal
+
+
+class TestAdanosDataProvider(TestCase):
+
+    def setUp(self):
+        self.provider = AdanosDataProvider(api_key="test-key")
+        self.start_date = datetime(2026, 5, 1)
+        self.end_date = datetime(2026, 5, 3)
+
+    def test_get_history_returns_daily_sentiment_series(self):
+        payload = {
+            "ticker": "AAPL",
+            "found": True,
+            "daily_trend": [
+                {"date": "2026-05-01", "sentiment_score": 0.1, "buzz_score": 20.0, "mentions": 4},
+                {"date": "2026-05-02", "sentiment_score": 0.2, "buzz_score": 25.0, "mentions": 6},
+            ],
+        }
+
+        with patch.object(self.provider, "_request_json", return_value=payload) as request_json:
+            result = self.provider.get_history(
+                BloombergTicker("AAPL US Equity"),
+                "sentiment_score",
+                self.start_date,
+                self.end_date,
+            )
+
+        request_json.assert_called_once_with(
+            "/reddit/stocks/v1/stock/AAPL",
+            {"from": "2026-05-01", "to": "2026-05-03"},
+        )
+        expected = QFSeries([0.1, 0.2], index=[datetime(2026, 5, 1), datetime(2026, 5, 2)])
+        expected.name = "AAPL US Equity"
+        expected.index.name = "dates"
+        assert_series_equal(result, expected)
+
+    def test_get_history_supports_multiple_tickers_and_fields(self):
+        tickers = [BloombergTicker("AAPL US Equity"), BloombergTicker("MSFT US Equity")]
+        payloads = [
+            {
+                "ticker": "AAPL",
+                "found": True,
+                "sentiment_score": 0.1,
+                "buzz_score": 20.0,
+                "mentions": 4,
+            },
+            {
+                "ticker": "MSFT",
+                "found": True,
+                "sentiment_score": -0.2,
+                "buzz_score": 15.0,
+                "mentions": 5,
+            },
+        ]
+
+        with patch.object(self.provider, "_request_json", side_effect=payloads):
+            result = self.provider.get_history(
+                tickers,
+                ["sentiment_score", "mentions"],
+                self.end_date,
+                self.end_date,
+            )
+
+        expected = QFDataFrame(
+            [[0.1, 4], [-0.2, 5]],
+            index=tickers,
+            columns=["sentiment_score", "mentions"],
+        )
+        expected.index.name = "tickers"
+        expected.columns.name = "fields"
+        assert_dataframes_equal(result, expected)
+
+    def test_get_history_rejects_non_daily_frequency(self):
+        with self.assertRaisesRegex(ValueError, "daily sentiment data only"):
+            self.provider.get_history(
+                BloombergTicker("AAPL US Equity"),
+                "sentiment_score",
+                self.start_date,
+                self.end_date,
+                frequency=Frequency.WEEKLY,
+            )
+
+    def test_get_history_uses_selected_source(self):
+        provider = AdanosDataProvider(api_key="test-key", source="x")
+        payload = {"ticker": "AAPL", "found": True, "sentiment_score": 0.1}
+
+        with patch.object(provider, "_request_json", return_value=payload) as request_json:
+            provider.get_history(
+                BloombergTicker("AAPL US Equity"),
+                "sentiment_score",
+                self.end_date,
+                self.end_date,
+            )
+
+        request_json.assert_called_once_with(
+            "/x/stocks/v1/stock/AAPL",
+            {"from": "2026-05-03", "to": "2026-05-03"},
+        )
+
+    def test_get_history_rejects_non_stock_ticker(self):
+        with self.assertRaisesRegex(ValueError, "stock tickers only"):
+            self.provider.get_history(
+                BloombergTicker("BTC US Equity", security_type=SecurityType.CRYPTO),
+                "sentiment_score",
+                self.start_date,
+                self.end_date,
+            )
+
+    def test_missing_api_key_raises_clear_error(self):
+        with patch.dict(os.environ, {}, clear=True):
+            with self.assertRaisesRegex(ValueError, "api_key or ADANOS_API_KEY"):
+                AdanosDataProvider()


### PR DESCRIPTION
## Summary
- add an optional AdanosDataProvider for daily stock sentiment fields through the standard DataProvider get_history interface
- support Reddit, X, News, and Polymarket stock sentiment sources without adding new package dependencies
- document the provider in the data providers autosummary and add mocked unit coverage

## Notes
- This is intentionally not an AbstractPriceDataProvider because Adanos supplies sentiment/attention data rather than OHLCV prices.
- The provider reads ADANOS_API_KEY when api_key is not passed explicitly.

## Tests
- /tmp/qf-lib-venv/bin/python -m pytest qf_lib/tests/unit_tests/data_providers/test_adanos_data_provider.py -q
- /tmp/qf-lib-venv/bin/python -m py_compile qf_lib/data_providers/adanos/adanos_data_provider.py qf_lib/data_providers/adanos/__init__.py qf_lib/tests/unit_tests/data_providers/test_adanos_data_provider.py
- git diff --check