### PR TITLE
Fix deprecated seaborn kwargs in KDEChart

### DIFF
--- a/qf_lib/plotting/charts/kde_chart.py
+++ b/qf_lib/plotting/charts/kde_chart.py
@@ -20,6 +20,10 @@ from qf_lib.plotting.charts.chart import Chart
 from qf_lib.plotting.decorators.data_element_decorator import DataElementDecorator
 
 
+def _translate_deprecated_kdeplot_settings(plot_settings: dict) -> dict:
+    return {{"bw": "bw_method", "shade": "fill"}.get(k, k): v for k, v in plot_settings.items()}
+
+
 class KDEChart(Chart):
     """
     Fits and plots a univariate (bivariate to be implemented) kernel density estimate using Seaborn's kdeplot function.
@@ -37,5 +41,5 @@ class KDEChart(Chart):
 
     def apply_data_element_decorators(self, data_element_decorators: List[DataElementDecorator]):
         for data_element in data_element_decorators:
-            plot_settings = data_element.plot_settings
+            plot_settings = _translate_deprecated_kdeplot_settings(data_element.plot_settings)
             sns.kdeplot(data_element.data, ax=self.axes, **plot_settings)

--- a/qf_lib/plotting/helpers/create_returns_similarity.py
+++ b/qf_lib/plotting/helpers/create_returns_similarity.py
@@ -59,13 +59,13 @@ def create_returns_similarity(strategy: QFSeries, benchmark: QFSeries, mean_norm
     scaled_strategy = preprocessing.scale(
         aggregate_strategy, with_mean=mean_normalization, with_std=std_normalization)
     strategy_data_element = DataElementDecorator(
-        scaled_strategy, bw="scott", shade=True, label=strategy.name, color=colors[0])
+        scaled_strategy, bw_method="scott", fill=True, label=strategy.name, color=colors[0])
     chart.add_decorator(strategy_data_element)
 
     scaled_benchmark = preprocessing.scale(
         aggregate_benchmark, with_mean=mean_normalization, with_std=std_normalization)
     benchmark_data_element = DataElementDecorator(
-        scaled_benchmark, bw="scott", shade=True, label=benchmark.name, color=colors[1])
+        scaled_benchmark, bw_method="scott", fill=True, label=benchmark.name, color=colors[1])
     chart.add_decorator(benchmark_data_element)
 
     # Add a title.


### PR DESCRIPTION
## Fix deprecated `sns.kdeplot` kwargs

Replace deprecated parameters in `create_returns_similarity.py`:

| Old | New |
|-----|-----|
| `bw="scott"` | `bw_method="scott"` |
| `shade=True` | `fill=True` |

Added `_translate_deprecated_kdeplot_settings()` in `kde_chart.py` to remap any legacy kwargs before they reach seaborn, preventing breakage in `v0.14.0`.

---

Closes #241 