### PR TITLE
Fix FutureWarning on empty/all-NA DataFrame concatenation (#247)

### DIFF
--- a/qf_lib/analysis/tearsheets/portfolio_analysis_sheet.py
+++ b/qf_lib/analysis/tearsheets/portfolio_analysis_sheet.py
@@ -307,7 +307,10 @@ class PortfolioAnalysisSheet(AbstractDocument):
                 lambda p: p.total_pnl if isinstance(p, BacktestPositionSummary) else 0)
         })
 
-        all_positions_pnl = pd.concat([closed_positions_pnl, open_positions_pnl], sort=False)
+        pnl_columns = closed_positions_pnl.columns.union(open_positions_pnl.columns, sort=False)
+        populated_pnl = [df for df in (closed_positions_pnl, open_positions_pnl) if not df.empty]
+        all_positions_pnl = pd.concat(populated_pnl).reindex(columns=pnl_columns) \
+            if populated_pnl else QFDataFrame(columns=pnl_columns)
 
         performance_dicts_series = all_positions_pnl.groupby(by="Tickers name").apply(
             self._performance_series_for_ticker)

--- a/qf_lib/data_providers/bloomberg/historical_data_provider.py
+++ b/qf_lib/data_providers/bloomberg/historical_data_provider.py
@@ -184,9 +184,10 @@ class HistoricalDataProvider:
                 try:
                     if not dates_fields_values.empty:
                         ticker = ticker_str_to_ticker[security_name]
-                        tickers_data_dict[ticker] = QFDataFrame(pd.concat(
-                            [dates_fields_values, tickers_data_dict[ticker]])
-                        )
+                        existing_data = tickers_data_dict[ticker]
+                        tickers_data_dict[ticker] = QFDataFrame(
+                            pd.concat([dates_fields_values, existing_data]) if not existing_data.empty
+                            else dates_fields_values)
                 except KeyError:
                     self.logger.warning(f"Received data for a ticker which was not present in the request: "
                                         f"{security_name}. The data for that ticker will be excluded from parsing.")


### PR DESCRIPTION
## Fix `FutureWarning` on empty/all-NA DataFrame concatenation

Running tearsheets or the Bloomberg data provider on pandas 2.2 emitted `FutureWarning`s because `pd.concat` was fed frames that could be empty or all-NA, whose columns pandas will stop dropping during dtype inference. This excludes those empty frames before concatenating.

| File | Change |
|------|--------|
| `portfolio_analysis_sheet.py` | Filter out empty frames before `pd.concat`, then reindex to the column union so per-ticker performance still sees both PnL columns. |
| `historical_data_provider.py` | Concatenate the accumulated per-ticker frame only when it is non-empty. |

Verified against pandas 2.2.3: the warnings are gone and behaviour is unchanged (columns, rows and types preserved, empty-backtest case still handled).

---

Closes #247 