### PR TITLE
Remove deprecated fastpath kwarg from QFSeries (#270)

### DIFF
--- a/qf_lib/containers/futures/futures_chain.py
+++ b/qf_lib/containers/futures/futures_chain.py
@@ -49,7 +49,7 @@ class FuturesChain(pd.Series):
         """
         The index consists of expiry dates of the future contracts.
         """
-        super().__init__(data=None, index=None, dtype=object, name=None, copy=False, fastpath=False)
+        super().__init__(data=None, index=None, dtype=object, name=None, copy=False)
 
         self._future_ticker = future_ticker  # type: FutureTicker
         self._data_provider = data_provider  # type: "DataProvider"

--- a/qf_lib/containers/series/qf_series.py
+++ b/qf_lib/containers/series/qf_series.py
@@ -28,12 +28,12 @@ class QFSeries(pd.Series, TimeIndexedContainer):
     """
 
     def __init__(self, data: object = None, index: object = None, dtype: object = None, name: object = None,
-                 copy: bool = False, fastpath: bool = False):
+                 copy: bool = False):
 
         empty_sequence_object = isinstance(data, Sequence) and not isinstance(data, str) and len(data) < 1
         if (data is None or empty_sequence_object) and dtype is None:
             dtype = np.dtype(np.float64)
-        super().__init__(data, index, dtype, name, copy, fastpath)
+        super().__init__(data, index, dtype, name, copy)
 
     @property
     def _constructor(self):


### PR DESCRIPTION
## Remove deprecated `fastpath` kwarg from `QFSeries`

`QFSeries` forwarded a `fastpath` argument to `pd.Series.__init__`, which is removed in pandas 3.0. No call site ever passed `fastpath=True` and pandas builds its internal Series via block managers, so the kwarg can be dropped without any behavioural change.

| File | Change |
|------|--------|
| `qf_series.py` | Drop the `fastpath` parameter from `QFSeries.__init__` and its `super().__init__` call (removed in pandas 3.0). |
| `futures_chain.py` | Remove the `fastpath=False` argument from the `super().__init__` call. |

The xarray-based `QFDataArray.fastpath` is intentionally left untouched, as it belongs to `xarray.DataArray` and is unaffected by the pandas change.

---

Closes #270 